### PR TITLE
Added removeEventListener() for Android back button into componentWillUnmount

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ class Modal extends Component {
          this.animateOffset(props.offset);
       }
    }
-   hardwareBackPress(){
+   hardwareBackPress() {
       if (this.state.open) {
          this.close();
          return true;
@@ -54,7 +54,7 @@ class Modal extends Component {
          BackAndroid.addEventListener('hardwareBackPress', this.hardwareBackPress);
       }
    }
-   componentWillUnmount(){
+   componentWillUnmount() {
       if (Platform.OS === 'android') {
          BackAndroid.removeEventListener('hardwareBackPress', this.hardwareBackPress);
       }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ class Modal extends Component {
          scale: new Animated.Value(0.8),
          offset: new Animated.Value(0)
       };
+
+      this.hardwareBackPress = this.hardwareBackPress.bind(this);
    }
    componentWillMount() {
       if (this.props.open) {
@@ -40,15 +42,21 @@ class Modal extends Component {
          this.animateOffset(props.offset);
       }
    }
+   hardwareBackPress(){
+      if (this.state.open) {
+         this.close();
+         return true;
+      }
+      return false;
+   }
    componentDidMount() {
       if (Platform.OS === 'android') {
-         BackAndroid.addEventListener('hardwareBackPress', () => {
-            if (this.state.open) {
-               this.close();
-               return true;
-            }
-            return false;
-         });
+         BackAndroid.addEventListener('hardwareBackPress', this.hardwareBackPress);
+      }
+   }
+   componentWillUnmount(){
+      if (Platform.OS === 'android') {
+         BackAndroid.removeEventListener('hardwareBackPress', this.hardwareBackPress);
       }
    }
    setPhase(toValue) {


### PR DESCRIPTION
When Modal dialog is unmounted, event listener for Android hardware back button press (```hardwareBackPress```) is still there. This leads to problems in multi-page applications and/or when using other listeners for that event.

So i decided to remove event listener on each ```componentWillUnmount```