### PR TITLE
rendere children even when initially open

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ class Modal extends Component {
    }
    componentWillMount() {
       if (this.props.open) {
+         this.setState({ children: this.props.children });
          this.open();
       }
    }


### PR DESCRIPTION
Fixes: If the modal is initially open the componentWillReceiveProps method is not called and
as a result the children are undefined when rendering.