### PR TITLE
Add optional containerProps and modalProps props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,9 @@ export interface ModalProps {
   modalDidClose?: () => void;
   closeOnTouchOutside?: boolean;
   containerStyle?: ReactNative.ViewStyle;
+  containerProps?: ReactNative.ViewProperties;
   modalStyle?: ReactNative.ViewStyle;
+  modalProperties?: ReactNative.ViewProperties;
   disableOnBackPress?: boolean;
 }
 

--- a/index.js
+++ b/index.js
@@ -142,7 +142,8 @@ class Modal extends Component {
     return (
       <View
         pointerEvents={open ? 'auto' : 'none'}
-        style={containerStyles}>
+        style={containerStyles}
+        {...this.props.containerProps}>
         <TouchableOpacity
           style={styles.absolute}
           disabled={!this.props.closeOnTouchOutside}
@@ -155,7 +156,8 @@ class Modal extends Component {
             styles.defaultModalStyle,
             this.props.modalStyle,
             {opacity, transform: [{scale}, {translateY: offset}]}
-          ]}>
+          ]}
+          {...this.props.modalProps}>
           {children}
         </Animated.View>
       </View>


### PR DESCRIPTION
I came across an issue where I wanted to add some accessibility props on the modal and was unable to do so. If there's an option to pass/override the props for the container and the modal, it'd be great.

This is a minor change. Closed because there was a typo in the type definition.