### PR TITLE
set initial offset

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ class Modal extends Component {
   state = {
     opacity: new Animated.Value(0),
     scale: new Animated.Value(0.8),
-    offset: new Animated.Value(0)
+    offset: new Animated.Value(this.props.offset)
   };
 
   componentWillMount() {


### PR DESCRIPTION
The modal offset is by default 0. This update will make it able to set the initial offset prop